### PR TITLE
Send the username to Hubspot in the id field.

### DIFF
--- a/Plugins/Hubspot/class.hubspot.plugin.php
+++ b/Plugins/Hubspot/class.hubspot.plugin.php
@@ -56,7 +56,7 @@ class HubspotPlugin extends Gdn_Plugin {
             echo '
             <script>
                 var _hsq = _hsq || [];
-                _hsq.push(["identify",{email: "'.htmlspecialchars($user->Email).'", firstname: "'.htmlspecialchars($user->Name).'"}]);
+                _hsq.push(["identify",{email: "'.htmlspecialchars($user->Email).'", id: "'.htmlspecialchars($user->Name).'"}]);
             </script>';
         }
 


### PR DESCRIPTION
We send the Vanilla user name in the 'firstname' field to Hubspot which is not technically accurate. This pull request would send the name as the 'id'.